### PR TITLE
time tracking web app toggl-track

### DIFF
--- a/toggle-track/LICENSE
+++ b/toggle-track/LICENSE
@@ -1,0 +1,5 @@
+This is an *unofficial* version of the web application, provided through an isolated web browser instance.
+
+For further information, visit the project repository at https://github.com/intersimone999/pyqtws.
+The complete license of the project is available at https://github.com/intersimone999/pyqtws/blob/master/LICENSE.
+The icon for this program is from the original website.

--- a/toggle-track/apps/toggl-track.qtws
+++ b/toggle-track/apps/toggl-track.qtws
@@ -1,0 +1,10 @@
+{
+        "name": "toggl track",
+        "description": "Time tracking webapp",
+        "scope": ["https:\\/\\/track.toggl.com/"],
+        "plugins": [],
+        "home": "https://track.toggl.com/",
+        "icon": "icons/toggl-track.svg",
+        "saveSession": false,
+        "menu": []
+}

--- a/toggle-track/desktops/toggl-track.desktop
+++ b/toggle-track/desktops/toggl-track.desktop
@@ -1,0 +1,13 @@
+[Desktop Entry]
+Categories=Internet;Utilities;
+Comment=Standalone silo app for toggle-track
+Exec=silo -a toggl-track
+GenericName=toggl track
+Icon=silo-toggl-track
+MimeType=
+Name=toggl track
+Path=
+StartupNotify=true
+Terminal=false
+Type=Application
+StartupWMClass=silos-toggl-track

--- a/toggle-track/icons/toggl-track.svg
+++ b/toggle-track/icons/toggl-track.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="156"
+   height="156"
+   viewBox="0 0 175.5 175.5"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="toggl-track.svg"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07, custom)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="5.25"
+     inkscape:cx="78"
+     inkscape:cy="78"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M 78.00975,87.243 78,87.75 c 0,5.421 4.368,9.75 9.75,9.75 H 117 c 5.421,0 9.75,-4.368 9.75,-9.75 C 126.75,82.329 122.382,78 117,78 H 97.5 V 39.02925 a 9.75,9.75 0 1 0 -19.5,0 v 47.7165 z M 87.75,175.5 a 87.75,87.75 0 1 0 0,-175.5 87.75,87.75 0 0 0 0,175.5 z"
+     fill="#fce5d8"
+     fill-rule="evenodd"
+     id="path2"
+     style="stroke-width:0.999999" />
+</svg>

--- a/toggle-track/info.json
+++ b/toggle-track/info.json
@@ -1,0 +1,5 @@
+{
+  "desc": "Standalone silo app for toggle-track",
+  "category": "Internet;Utilities;",
+  "version": "0.1"
+}


### PR DESCRIPTION
I created the app/icon/desktop files for a time tracking web app I use a lot and would be happy to have as a silos app: https://track.toggle.com/. Would be great if you could take it into the silos-apps repository. If I’m not mistaken, you also maintain the PKGBUILDs in the Arch Linux AUR, so I guess it’s better if I leave that to you? Thanks for the great work!